### PR TITLE
fix arrays observability

### DIFF
--- a/src/persistenceDecorator.ts
+++ b/src/persistenceDecorator.ts
@@ -30,6 +30,12 @@ function getObservableTargetObject<T extends Object>(target: T, properties: (key
     }
 
     if (target.hasOwnProperty(property)) {
+      let value: T[keyof T] | any[] = target[property]
+
+      if (Array.isArray(value)) {
+        value = value.slice()
+      }
+
       return { ...result, [property]: target[property] };
     }
 


### PR DESCRIPTION
When persisted observable is array and you mutate it using push, pop or unshift it won't trigger reaction in persistenceDecorator and thus changes won't be persisted

```
@persistence({
  name: 'NumberStore',
  properties: ['numbersArray'],
  adapter: new StorageAdapter({
    read: readStore,
    write: writeStore,
  })
})
class NumberStore {
  @observable numbersArray = [1,2,3,4,5]

  @action addNumber = () => {
    this.numbersArray.push(6) // this change won't be persisted
  };
}
```