### PR TITLE
fix objects observability

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,10 +36,13 @@ export function getObservableTargetObject<T extends Object>(target: T, propertie
     }
 
     if (target.hasOwnProperty(property)) {
-      let value: T[keyof T] | any[] = target[property];
+      let value: T[keyof T] | string = target[property];
 
-      if (Array.isArray(value)) {
-        value = value.slice();
+      /**
+       * This makes objects recursively observable for mutable changes
+       */
+      if (typeof value === 'object') {
+        value = JSON.stringify(value)
       }
 
       return { ...result, [property]: target[property] };


### PR DESCRIPTION
When persisted observable is object and you mutate its deep properties reaction won't be triggered in persistenceDecorator and thus changes won't be persisted

```
@persistence({
  name: 'ObjectStore',
  properties: ['objectsArray'],
  adapter: new StorageAdapter({
    read: readStore,
    write: writeStore,
  })
})
class ObjectStore {
  @observable objectsArray = [{
    prop1: {
      prop2: 1
    }
  }]

  @action mutate = () => {
    this.objectsArray[0].prop1.prop2++ // this change won't be persisted
  };
}
```