### PR TITLE
isFunction handles additional situations

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export const isObjectWithProperties = (data: any): boolean => {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const isFunction = (functionToCheck: any): boolean => {
-  return functionToCheck && functionToCheck instanceof Function;
+  return functionToCheck && typeof functionToCheck === 'function';
 };
 
 export const isStorageControllerLike = (value: StorageController | Storage | undefined): value is StorageController => {


### PR DESCRIPTION
The current `isFunction` implementation is:

```typescript
export const isFunction = (functionToCheck: any): boolean => {
  return functionToCheck && functionToCheck instanceof Function;
};
```

This PR changes it to use `typeof`:

```typescript
export const isFunction = (functionToCheck: any): boolean => {
  return functionToCheck && typeof functionToCheck === 'function';
};
```

This is the implementation [advised by the jQuery team](https://api.jquery.com/jquery.isfunction/).

The current `isFunction` will produce incorrect values for some stores. For example, the [AsyncStorage mock](https://github.com/react-native-async-storage/async-storage/blob/master/jest/async-storage-mock.js) module will incorrectly show that it is missing functions:

```
      mobx-persist-store: Profile does not have a valid storage adaptor.
      
      * Make sure the storage controller has 'getItem', 'setItem' and 'removeItem' methods."
```

This may be the cause of #96 as well.