### PR TITLE
Support ES6 Set

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -167,6 +167,30 @@ export class SampleStore {
 
 `configurePersistable` sets items globally, but you can override them within `makePersistable`.
 
+## ES6 Map and Set Support
+
+This library has built-in support for persisting ES6 Map and Set objects. When a property is an instance of `ObservableMap` or `ObservableSet`, it will be automatically serialized to an array format and then deserialized back to a Map or Set when the store is hydrated.
+
+```javascript
+import { makeAutoObservable } from 'mobx';
+import { makePersistable } from 'mobx-persist-store';
+
+export class SampleStore {
+  mapProperty = new Map([['key1', 'value1'], ['key2', 'value2']]);
+  setProperty = new Set(['item1', 'item2', 'item3']);
+
+  constructor() {
+    makeAutoObservable(this);
+
+    makePersistable(this, {
+      name: 'SampleStore',
+      properties: ['mapProperty', 'setProperty'],
+      storage: window.localStorage,
+    });
+  }
+}
+```
+
 ## API
 
 You should only need `makePersistable` but this library also provides other utils for more advance usage.

--- a/src/PersistStore.ts
+++ b/src/PersistStore.ts
@@ -6,6 +6,7 @@ import {
   makeObservable,
   observable,
   ObservableMap,
+  ObservableSet,
   reaction,
   runInAction,
   toJS,
@@ -21,6 +22,7 @@ import {
   consoleDebug,
   invalidStorageAdaptorWarningIf,
   isArrayForMap,
+  isArrayForSet,
 } from './utils';
 
 export class PersistStore<T, P extends keyof T> {
@@ -117,6 +119,8 @@ export class PersistStore<T, P extends keyof T> {
 
               if (target[property.key] instanceof ObservableMap && isArrayForMap(propertyData)) {
                 target[property.key] = property.deserialize(new Map(propertyData));
+              } else if (target[property.key] instanceof ObservableSet && isArrayForSet(propertyData)) {
+                target[property.key] = property.deserialize(new Set(propertyData));
               } else {
                 target[property.key] = property.deserialize(propertyData);
               }
@@ -159,11 +163,17 @@ export class PersistStore<T, P extends keyof T> {
             let propertyData = property.serialize(target[property.key]);
 
             if (propertyData instanceof ObservableMap) {
-              const mapArray: any = [];
-              propertyData.forEach((v, k) => {
+              const mapArray: any[] = [];
+              propertyData.forEach((v: any, k: any) => {
                 mapArray.push([k, toJS(v)]);
               });
               propertyData = mapArray;
+            } else if (propertyData instanceof ObservableSet) {
+              const setArray: any[] = [];
+              propertyData.forEach((v: any) => {
+                setArray.push(toJS(v));
+              });
+              propertyData = setArray;
             }
 
             propertiesToWatch[property.key] = toJS(propertyData);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,6 +100,10 @@ export const isArrayForMap = (value: unknown): value is [any, any][] => {
   return false;
 };
 
+export const isArrayForSet = (value: unknown): value is any[] => {
+  return Array.isArray(value);
+};
+
 export const omitObjectProperties = <V>(obj: Record<string, V>, testFn: (value: V) => boolean) => {
   Object.keys(obj).forEach((key) => testFn(obj[key]) && delete obj[key]);
   return obj;


### PR DESCRIPTION
Hi, I noticed we only had support for Maps but not Sets.

This adds support for ES6 Set objects in the library, so now you can persist both Map and Set collections without any extra work.

What I did:
- Added a simple utility to handle Sets (similar to what we had for Maps)
- Updated the hydration/serialization logic to recognize and handle Sets
- Added some examples in the README so people know this feature exists