### PR TITLE
Fix accessor observables

### DIFF
--- a/src/PersistStore.ts
+++ b/src/PersistStore.ts
@@ -108,7 +108,7 @@ export class PersistStore<T, P extends keyof T> {
         runInAction(() => {
           this.properties.forEach((property) => {
             const allowPropertyHydration = [
-              target.hasOwnProperty(property.key),
+              property.key in target || target.hasOwnProperty(property.key),
               typeof data[property.key] !== 'undefined',
             ].every(Boolean);
 

--- a/src/PersistStore.ts
+++ b/src/PersistStore.ts
@@ -108,7 +108,7 @@ export class PersistStore<T, P extends keyof T> {
         runInAction(() => {
           this.properties.forEach((property) => {
             const allowPropertyHydration = [
-              property.key in target || target.hasOwnProperty(property.key),
+              property.key in target,
               typeof data[property.key] !== 'undefined',
             ].every(Boolean);
 


### PR DESCRIPTION
Hi! Mobx 6 recommends using the accessor keyword when defining observables and will make them mandatory in v7 when support for legacy decorators will be removed ([see docs](https://mobx.js.org/enabling-decorators.html#using-observer-as-a-decorator))

The issue: hydration of observables defined with the accessor keyword fails because `target.hasOwnProperty(property.key)` always returns false.

The solution: use `property.key in target` check instead.

